### PR TITLE
Update spymemcached

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ connection, while stopping the component will close it.
 Add the following dependency to your project.clj file:
 
 ```clojure
-[listora/memcached-component "0.1.1"]
+[listora/memcached-component "0.1.2"]
 ```
 
 ## Usage

--- a/project.clj
+++ b/project.clj
@@ -1,10 +1,9 @@
-(defproject listora/memcached-component "0.1.1"
+(defproject listora/memcached-component "0.1.2-SNAPSHOT"
   :description "A component for managing a connection to Memcached"
   :url "https://github.com/listora/memcached-component"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :repositories {"spy-memcached" {:url "http://files.couchbase.com/maven2/"}}
   :dependencies [[com.stuartsierra/component "0.2.2"]
                  [clojurewerkz/spyglass "1.1.0" :exclusions [spy/spymemcached]]
                  [org.clojure/clojure "1.6.0"]
-                 [spy/spymemcached "2.8.9"]])
+                 [net.spy/spymemcached "2.11.4"]])


### PR DESCRIPTION
Latest version is 2.11.4 and the group id has changed. We update the version, in the hope it fixes an issue on one of our production systems.
