### PR TITLE
Add support for text connections

### DIFF
--- a/src/listora/component/memcached.clj
+++ b/src/listora/component/memcached.clj
@@ -3,7 +3,8 @@
             [com.stuartsierra.component :as component]))
 
 (defn- silence-spyglass-logger! []
-  (System/setProperty "net.spy.log.LoggerImpl" "net.spy.memcached.compat.log.SunLogger")
+  (System/setProperty "net.spy.log.LoggerImpl"
+                      "net.spy.memcached.compat.log.SunLogger")
   (spyglass/set-log-level! :severe))
 
 (defn- spyglass-connection

--- a/src/listora/component/memcached.clj
+++ b/src/listora/component/memcached.clj
@@ -1,6 +1,6 @@
 (ns listora.component.memcached
-  (:require [com.stuartsierra.component :as component]
-            [clojurewerkz.spyglass.client :as spyglass]))
+  (:require [clojurewerkz.spyglass.client :as spyglass]
+            [com.stuartsierra.component :as component]))
 
 (defn- silence-spyglass-logger! []
   (System/setProperty "net.spy.log.LoggerImpl" "net.spy.memcached.compat.log.SunLogger")

--- a/src/listora/component/memcached.clj
+++ b/src/listora/component/memcached.clj
@@ -7,16 +7,37 @@
                       "net.spy.memcached.compat.log.SunLogger")
   (spyglass/set-log-level! :severe))
 
-(defn- spyglass-connection
-  [{:keys [servers username password auth-type failure-mode]}]
-  (let [auth-descrip (if (and username password)
-                       (if auth-type
-                         (spyglass/auth-descriptor username password auth-type)
-                         (spyglass/auth-descriptor username password)))
-        conn-factory (spyglass/bin-connection-factory
-                      :auth-descriptor auth-descrip
-                      :failure-mode    failure-mode)]
-    (spyglass/bin-connection servers conn-factory)))
+(def ^:private default-options
+  {:auth-type :plain
+   :client spyglass/bin-connection
+   :conn-type :binary
+   :factory spyglass/bin-connection-factory
+   :failure-mode :redistribute})
+
+(defn- using-auth?
+  [{:keys [username password]}]
+  (or username password))
+
+(defn normalize-options
+  [config]
+  {:pre [(-> config :servers string?)]
+   :post [(:auth-type %) (:client %) (:conn-type %) (:factory %)
+          (-> % :servers string?)]}
+  (let [options (merge default-options config)
+        {:keys [username password auth-type conn-type]} options]
+    (cond-> options
+      (= conn-type :text)
+      (assoc :client spyglass/text-connection
+             :factory spyglass/text-connection-factory)
+
+      (using-auth? options)
+      (assoc :auth-descriptor (spyglass/auth-descriptor username
+                                                        password
+                                                        auth-type)))))
+
+(defn build-connection
+  [{:keys [client factory servers] :as component}]
+  (client servers (apply factory component)))
 
 (defrecord MemcachedClient [servers username password failure-mode]
   component/Lifecycle
@@ -24,7 +45,7 @@
     (silence-spyglass-logger!)
     (if (:conn component)
       component
-      (assoc component :conn (spyglass-connection component))))
+      (assoc component :conn (build-connection component))))
   (stop [component]
     (when-let [conn (:conn component)]
       (spyglass/shutdown conn))
@@ -38,6 +59,9 @@
     :username     - an optional username for authentication
     :password     - an optional password for authentication
     :auth-type    - :cram-md5 or :plain
+    :conn-type    - :text or :binary. Defaults to :binary
     :failure-mode - :redistribute, :retry or :cancel"
-  [config]
-  (map->MemcachedClient (merge {:failure-mode :redistribute} config)))
+  [options]
+  (-> options
+      normalize-options
+      map->MemcachedClient))

--- a/test/listora/component/memcached_test.clj
+++ b/test/listora/component/memcached_test.clj
@@ -1,13 +1,69 @@
 (ns listora.component.memcached-test
+  (:import [net.spy.memcached.auth AuthDescriptor])
   (:require [clojure.test :refer :all]
             [com.stuartsierra.component :as component]
             [clojurewerkz.spyglass.client :as spyglass]
             [listora.component.memcached :refer :all]))
 
+(def ^:const ^:private servers
+  "127.0.0.1:11211")
+
+(deftest test-normalize-options
+  (testing "defaults"
+    (let [options (normalize-options {:servers servers})]
+      (is (= (:auth-type options) :plain))
+      (is (= (:client options) spyglass/bin-connection))
+      (is (= (:conn-type options) :binary))
+      (is (= (:factory options) spyglass/bin-connection-factory))
+      (is (nil? (:password options)))
+      (is (nil? (:username options)))
+      (is (nil? (:auth-descriptor options)))))
+
+  (testing "with auth"
+    (let [options (normalize-options {:username "user"
+                                      :password "pass"
+                                      :servers servers})]
+      (is (= (:auth-type options) :plain))
+      (is (= (:client options) spyglass/bin-connection))
+      (is (= (:conn-type options) :binary))
+      (is (= (:factory options) spyglass/bin-connection-factory))
+      (is (= (:password options) "pass"))
+      (is (= (:username options) "user"))
+      (is (instance? AuthDescriptor (:auth-descriptor options)))))
+
+  (testing "text connections"
+    (let [options (normalize-options {:conn-type :text
+                                      :servers servers})]
+      (is (= (:auth-type options) :plain))
+      (is (= (:client options) spyglass/text-connection))
+      (is (= (:conn-type options) :text))
+      (is (= (:factory options) spyglass/text-connection-factory))
+      (is (nil? (:password options)))
+      (is (nil? (:username options)))
+      (is (nil? (:auth-descriptor options)))))
+
+  (testing "text connections with auth"
+    (let [options (normalize-options {:conn-type :text
+                                      :username "user"
+                                      :password "pass"
+                                      :servers servers})]
+      (is (= (:auth-type options) :plain))
+      (is (= (:client options) spyglass/text-connection))
+      (is (= (:conn-type options) :text))
+      (is (= (:factory options) spyglass/text-connection-factory))
+      (is (= (:password options) "pass"))
+      (is (= (:username options) "user"))
+      (is (instance? AuthDescriptor (:auth-descriptor options)))))
+
+  (testing "cram-md5"
+    (let [options (normalize-options {:auth-type :cram-md5
+                                      :servers servers})]
+      (is (= (:auth-type options) :cram-md5)))))
+
 ;; These tests assume memcached is started and listening on port 11211
 
 (deftest test-memcached-client
-  (let [component (memcached-client {:servers "127.0.0.1:11211"})]
+  (let [component (memcached-client {:servers servers})]
     (testing "initial values"
       (is (= (:servers component) "127.0.0.1:11211"))
       (is (nil? (:conn component))))


### PR DESCRIPTION
Fixes #3 with a few modifications…

I've split things up into a set of pure operations that produce a hash-map of data that can be used to build an actual connection, and I use this data inside the component.

Few things I'm not super happy about. Firstly, using a key-value pair to indicate the type of connection, which to my knowledge can only ever be binary or text, seems like something that'll trip people up in future. As we're dealing with a switch for "binary connection or text" a boolean might make more sense, and was how I implemented this initially. I opted for the key-value pair instead as that's a drop-in solution for the group who requested this feature.

The other thing that bugs me a little is Spyglass itself. The connection-factory-builder-auth-descriptor functions could be easier to use. A lot of the contortion required here would likely disappear if we could simplify the connection-building functions in Spyglass to work in a more data-orientated way.
